### PR TITLE
Cf 548 - Investigate spark 1.2 to allow order by timestamp

### DIFF
--- a/tiamat/build.gradle
+++ b/tiamat/build.gradle
@@ -27,8 +27,8 @@ shadowJar {
 
     dependencies {
         exclude(dependency('org.scala-lang:scala-library:2.10.4'))
-        exclude(dependency('org.apache.spark:spark-core_2.10:1.1.1'))
-        exclude(dependency('org.apache.spark:spark-hive_2.10:1.1.1'))
+        exclude(dependency('org.apache.spark:spark-core_2.10:1.2.1'))
+        exclude(dependency('org.apache.spark:spark-hive_2.10:1.2.1'))
     }
 
     relocate 'org.apache.http', 'shaded.org.apache.http'

--- a/tiamat/src/main/scala/com/rackspace/feeds/archives/Archiver.scala
+++ b/tiamat/src/main/scala/com/rackspace/feeds/archives/Archiver.scala
@@ -1,5 +1,6 @@
 package com.rackspace.feeds.archives
 
+import java.sql.Timestamp
 import java.util.UUID
 
 import org.apache.spark.rdd.RDD
@@ -7,6 +8,7 @@ import org.apache.spark.sql.hive.HiveContext
 import org.apache.spark.sql._
 import org.apache.spark._
 import org.apache.spark.SparkContext._
+import org.joda.time.{DateTimeZone, DateTime}
 
 import org.slf4j.LoggerFactory
 
@@ -308,7 +310,7 @@ object Archiver {
       row.getString( 1 ),
       row.getString( 2 ),
       row.getString( 3 ),
-      null, // TODO: looks like Timestamp was fixed in 1.2
+      row( 4 ).asInstanceOf[Timestamp],
       row.getLong( 5 ),
       row.getString( 6 ),
       row.getString( 7 )
@@ -365,7 +367,7 @@ object Archiver {
 
       prefMap( tenantid ).formats.flatMap( f =>
         List(( ArchiveKey( tenantid, entry.region, entry.feed, entry.date, f ),
-          AtomEntry( entrybody, /*isoFormat.parseDateTime( row.getString(4)), */ entry.id))))
+          AtomEntry( entrybody, new DateTime( entry.datelastupdated.getTime, DateTimeZone.UTC ), entry.id))))
     }
   }
 

--- a/tiamat/src/main/scala/com/rackspace/feeds/archives/Tiamat.scala
+++ b/tiamat/src/main/scala/com/rackspace/feeds/archives/Tiamat.scala
@@ -63,8 +63,6 @@ object Tiamat {
 
   val logger = LoggerFactory.getLogger(getClass)
 
-  val isoFormat = ISODateTimeFormat.basicDateTime()
-
   /**
    * The method run by Spark to execute the job.
    *
@@ -132,15 +130,12 @@ object ArchiveKey {
 
 
 // TODO: looks like Timestamp was fixed in 1.2
-case class AtomEntry( entrybody : String, /*datelastupdated : DateTime, */ id : Long ) extends Ordered[AtomEntry] {
+case class AtomEntry( entrybody : String, datelastupdated : DateTime, id : Long ) extends Ordered[AtomEntry] {
 
   import scala.math.Ordered.orderingToOrdered
 
   def compare(that: AtomEntry): Int = {
 
-
-    id.compare( that.id )
-    /*
     import Joda._
 
     datelastupdated.compare( that.datelastupdated ) match {
@@ -148,7 +143,5 @@ case class AtomEntry( entrybody : String, /*datelastupdated : DateTime, */ id : 
       case 0 => id.compare( that.id )
       case c => c
     }
-
-    */
   }
 }

--- a/tiamat/src/main/scala/com/rackspace/feeds/archives/XmlProcessing.scala
+++ b/tiamat/src/main/scala/com/rackspace/feeds/archives/XmlProcessing.scala
@@ -90,7 +90,7 @@ object XmlProcessing {
     (transformer.asInstanceOf[Controller]).setInitialTemplate( "main" )
     transformer.transform( source, result )
 
-    AtomEntry(  makeArrayEntry( out.toString( "UTF-8" ) ), entry.id )
+    AtomEntry(  makeArrayEntry( out.toString( "UTF-8" ) ), entry.datelastupdated, entry.id )
   }
 
   def makeArrayEntry(json: String): String = {

--- a/tiamat/src/main/scala/com/rackspace/feeds/archives/util/createHiveInput.scala
+++ b/tiamat/src/main/scala/com/rackspace/feeds/archives/util/createHiveInput.scala
@@ -40,6 +40,9 @@ object CreateHiveInput {
 
     val num_feeds_user = (( total_entries / ( feeds.length + nasty_feeds.length ) ) * percent_single_user).toInt
 
+    // to test that timestamps are ordered and not indexes
+    val total = feeds.size * users.size * num_feeds_user
+
     feeds.zipWithIndex.foreach { case( feed, fI )=>
 
       users.zipWithIndex.foreach { case( u, uI ) =>

--- a/tiamat/src/test/scala/com.rackspace.feeds.archives/ArchiverTest.scala
+++ b/tiamat/src/test/scala/com.rackspace.feeds.archives/ArchiverTest.scala
@@ -1,5 +1,6 @@
 package com.rackspace.feeds.archives
 
+import org.joda.time.{DateTimeZone, DateTime}
 import org.junit.runner.RunWith
 import org.scalatest.FunSuite
 import org.scalatest.junit.JUnitRunner
@@ -13,6 +14,8 @@ import java.sql.Timestamp
 class ArchiverTest extends FunSuite with MockitoSugar {
 
   import Archiver._
+
+  val DATE_LAST_UPDATED = new DateTime( 2014, 2, 18, 21, 12, 10, 997, DateTimeZone.UTC )
 
   val CHECK_XML = """<atom:entry xmlns="http://www.w3.org/2001/XMLSchema"
                     |            xmlns:xsd="http://www.w3.org/2001/XMLSchema"
@@ -170,7 +173,7 @@ class ArchiverTest extends FunSuite with MockitoSugar {
                                   |  <atom:updated>2014-02-18T21:12:10.997Z</atom:updated>
                                   |  <atom:published>2014-02-18T21:12:10.997Z</atom:published>
                                   |</atom:entry>
-                                  |""".stripMargin, 1 )
+                                  |""".stripMargin, DATE_LAST_UPDATED, 1 )
 
     val entry = Entry( protoKey.tenantid, protoKey.region, protoKey.feed,
       """<atom:entry xmlns:atom="http://www.w3.org/2005/Atom" xmlns="http://wadl.dev.java.net/2009/02" xmlns:db="http://docbook.org/ns/docbook" xmlns:error="http://docs.rackspace.com/core/error" xmlns:d312e1="http://wadl.dev.java.net/2009/02" xmlns:wadl="http://wadl.dev.java.net/2009/02" xmlns:usage-summary="http://docs.rackspace.com/core/usage-summary">
@@ -212,7 +215,7 @@ class ArchiverTest extends FunSuite with MockitoSugar {
 
     val protoKey = ArchiveKey( "1234", "dfw", "feed1", "2014-02-18", "XML" )
 
-    val protoEntry = AtomEntry( CHECK_XML, 1 )
+    val protoEntry = AtomEntry( CHECK_XML, DATE_LAST_UPDATED, 1 )
 
     val row = Entry( protoKey.tenantid,
       protoKey.region,
@@ -236,7 +239,7 @@ class ArchiverTest extends FunSuite with MockitoSugar {
 
     val protoKey = ArchiveKey( "1234", "dfw", "feed1", "2014-02-18", CreateFilesFeed.XML_KEY )
 
-    val protoEntry = AtomEntry( CHECK_XML, 1 )
+    val protoEntry = AtomEntry( CHECK_XML, DATE_LAST_UPDATED, 1 )
 
     val nastId = "1234_nast"
 
@@ -260,7 +263,7 @@ class ArchiverTest extends FunSuite with MockitoSugar {
   test( "processJson() into JSON" ) {
 
     val inKey = ArchiveKey( "1234", "dfw", "feed1", "2014-02-18", CreateFilesFeed.JSON_KEY )
-    val inEntry = AtomEntry( CHECK_XML, 1 )
+    val inEntry = AtomEntry( CHECK_XML, DATE_LAST_UPDATED, 1 )
 
     val( outKey, outEntry ) = processJson( ( inKey, inEntry))
 
@@ -272,7 +275,7 @@ class ArchiverTest extends FunSuite with MockitoSugar {
   test( "processJson() into XML" ) {
 
     val inKey = ArchiveKey( "1234", "dfw", "feed1", "2014-02-18", CreateFilesFeed.XML_KEY )
-    val inEntry = AtomEntry( CHECK_XML, 1 )
+    val inEntry = AtomEntry( CHECK_XML, DATE_LAST_UPDATED, 1 )
 
     val( outKey, outEntry ) = processJson( ( inKey, inEntry))
 

--- a/tiamat/src/test/scala/com.rackspace.feeds.archives/CreateFilesFeedTest.scala
+++ b/tiamat/src/test/scala/com.rackspace.feeds.archives/CreateFilesFeedTest.scala
@@ -3,6 +3,7 @@ package com.rackspace.feeds.archives
 import java.io.ByteArrayOutputStream
 
 import org.codehaus.jackson.map.ObjectMapper
+import org.joda.time.{DateTimeZone, DateTime}
 import org.junit.runner.RunWith
 import org.scalatest.FunSuite
 import org.scalatest.junit.JUnitRunner
@@ -15,6 +16,9 @@ class CreateFilesFeedTest extends FunSuite {
 
   import CreateFilesFeed._
   import Archiver._
+
+  val DATE_LAST_UPDATED_1 = new DateTime( 2014, 2, 18, 21, 12, 10, 997, DateTimeZone.UTC )
+  val DATE_LAST_UPDATED_0 = new DateTime( 2014, 2, 18, 21, 12, 10, 0, DateTimeZone.UTC )
 
   val PREFACE = """<?xml version="1.0" encoding="UTF-8" ?>
       <feed xmlns="http://www.w3.org/2005/Atom"
@@ -116,7 +120,7 @@ class CreateFilesFeedTest extends FunSuite {
                        |  <atom:updated>2014-02-18T21:12:10.997Z</atom:updated>
                        |  <atom:published>2014-02-18T21:12:10.997Z</atom:published>
                        |</atom:entry>
-                       |""".stripMargin, 1 ),
+                       |""".stripMargin, DATE_LAST_UPDATED_1, 1 ),
       AtomEntry( """<atom:entry xmlns:usage-summary="http://docs.rackspace.com/core/usage-summary"
                    |            xmlns:wadl="http://wadl.dev.java.net/2009/02"
                    |            xmlns:d312e1="http://wadl.dev.java.net/2009/02"
@@ -161,7 +165,7 @@ class CreateFilesFeedTest extends FunSuite {
                    |  <atom:updated>2014-02-18T21:12:10.997Z</atom:updated>
                    |  <atom:published>2014-02-18T21:12:10.997Z</atom:published>
                    |</atom:entry>
-                   |""".stripMargin, 0) )
+                   |""".stripMargin, DATE_LAST_UPDATED_0, 0) )
   }
 
   def getJsonEvents() : Iterable[AtomEntry] = {
@@ -217,7 +221,7 @@ class CreateFilesFeedTest extends FunSuite {
                        |        "id": "urn:uuid:1",
                        |        "title": "Widget"
                        |    }
-                       |""".stripMargin, 1 ),
+                       |""".stripMargin, DATE_LAST_UPDATED_1, 1 ),
       AtomEntry( """{
                    |        "category": [
                    |            {
@@ -269,7 +273,7 @@ class CreateFilesFeedTest extends FunSuite {
                    |        "id": "urn:uuid:e53d007a-fc23-11e1-975c-cfa6b29bb814",
                    |        "title": "Widget"
                    |    }
-                   |""".stripMargin, 0) )
+                   |""".stripMargin, DATE_LAST_UPDATED_0, 0) )
   }
 
 


### PR DESCRIPTION
Tested spark 1.2 on our test node & updated code to order entries by datelastupdated timestamp.

Please first accept:  https://github.com/rackerlabs/cloudfeeds-nabu/pull/8