### PR TITLE
CF-584: minor fixes: include *.ddl files in RPM, comment out unneeded prefs workflow

### DIFF
--- a/usmu/build.gradle
+++ b/usmu/build.gradle
@@ -67,6 +67,7 @@ ospackage {
         include '*-coordinator.xml'
         include '*-wf.xml'
         include '*.q'
+        include '*.ddl'
         // set permissions
         user app_user
         permissionGroup app_group

--- a/usmu/src/main/resources/usmu-install-to-hdfs.sh
+++ b/usmu/src/main/resources/usmu-install-to-hdfs.sh
@@ -34,7 +34,3 @@ hadoop fs -copyFromLocal -f ${USMU_ETC_DIR}/hive-site.xml ${USMU_HDFS_DIR}/feeds
 hadoop fs -copyFromLocal -f ${USMU_INSTALL_DIR}/copy_to_entries.q ${USMU_HDFS_DIR}/feedsImport/
 hadoop fs -copyFromLocal -f ${USMU_INSTALL_DIR}/feedsImport-wf.xml ${USMU_HDFS_DIR}/feedsImport/workflow.xml
 
-# copying files related to the PrefsImport workflow
-hadoop fs -copyFromLocal -f ${USMU_ETC_DIR}/hive-site.xml ${USMU_HDFS_DIR}/prefsImport/
-hadoop fs -copyFromLocal -f ${USMU_INSTALL_DIR}/load_prefs.q ${USMU_HDFS_DIR}/prefsImport/
-hadoop fs -copyFromLocal -f ${USMU_INSTALL_DIR}/prefsImport-wf.xml ${USMU_HDFS_DIR}/prefsImport/workflow.xml


### PR DESCRIPTION
A few install/deploy issues I came across while testing Usmu in public cloud:
*) RPM did not contain any of the *.ddl file
*) Install script incorrectly still referenced the Preferences Svc workflow, which we decided not to use