### PR TITLE
CF-703: create success.txt file on successful daily run of Usmu workflow

### DIFF
--- a/usmu/src/main/resources/feedsImport-wf.xml
+++ b/usmu/src/main/resources/feedsImport-wf.xml
@@ -17,8 +17,13 @@
     - hdfsDumpDir    - this is the fully qualified HDFS path where the workflow
                        needs to read exported data from Postgres DB dump
                        and writes to Hive. For example:
-                          hdfs://myhadoop.cluster.host/cloudfeeds/feeds_dump/DFW/2015-02-17
-
+                          hdfs://myhadoop.cluster.host/user/cloudfeeds/feeds_dump/DFW/2015-02-17
+    - successDir     - the path to where Usmu should write a success.txt file
+                       on successful run of the daily workflow. The path should
+                       should look like this:
+                          /user/cloudfeeds/put/success/file/somewhere
+                       The actual success.txt file would be placed in sub directories like this:
+                          /user/cloudfeeds/put/success/file/somewhere/DFW/2015-04-12
 -->
 <workflow-app name="usmu" 
 	      xmlns="uri:oozie:workflow:0.4">
@@ -33,8 +38,11 @@
     <property>
        <name>hdfsDumpDir</name>
     </property>
+    <property>
+       <name>successDir</name>
+    </property>
   </parameters>
-
+ 
   <start to="copy_to_entries"/>
 
   <action name="copy_to_entries">
@@ -64,7 +72,7 @@
            From the Coordinator, we get the hdfsDumpDir which is the directory
            where we will expect Postgres DB dump files to exist. The value
            of hdfsDumpDir will be a fully qualified hdfs path (i.e: 
-           hdfs://myname.node/cloudfeeds/feeds_dump/DFW/2015-02-17). But
+           hdfs://myname.node/users/cloudfeeds/feeds_dump/DFW/2015-02-17). But
            Hive script does not take a fully qualified hdfs path. So I 
            have to strip the nameNode out. This is what the replaceAll()
            does.
@@ -83,6 +91,20 @@
          Someone or some process needs to purge these
          -->
          <move source="${hdfsDumpDir}" target="${hdfsDumpDir}-${wf:id()}"/>
+     </fs>
+     <ok to="createSuccess"/>
+     <error to="sendEmailKill"/>
+  </action>
+
+  <action name="createSuccess">
+     <fs>
+         <!--
+             The coordinator will pass in the hdfsDumpDir, which looks something like this:
+                 hdfs://nameNode/user/cloudfeeds/cloudfeeds-ballista/feeds_dump/DFW/2015-04-22
+             The following replaceAll() call essentially grabs that last slug (which is the 
+             run date.
+         -->
+         <touchz path="${nameNode}${successDir}/${region}/${replaceAll(hdfsDumpDir, concat(concat(concat(nameNode, '/(.+)/'), region), '/([0-9\\-]+)/?'), '$2')}/success.txt"/>
      </fs>
      <ok to="end"/>
      <error to="sendEmailKill"/>

--- a/usmu/src/main/resources/usmu-coord-run.sh
+++ b/usmu/src/main/resources/usmu-coord-run.sh
@@ -49,6 +49,7 @@ do
         -DcoordAppName=FeedsImport-${aRegion} \
         -DwatchDir=${FEEDS_DUMP_DIR}/${aRegion} \
         -DworkflowPath=${USMU_HDFS_DIR}/feedsImport \
+        -DsuccessDir=${USMU_SUCCESS_DIR} \
         -Dregion=$aRegion -DemailToAddress="${ERROR_EMAIL}" \
         -DstartTime="${START_TIME}" -DendTime="${END_TIME}"
 done

--- a/usmu/src/main/resources/usmu-coordinator.properties
+++ b/usmu/src/main/resources/usmu-coordinator.properties
@@ -34,11 +34,18 @@ OOZIE_URL=http://cloudfeeds-visual-n02.test.ord1.ci.rackspace.net:11000/oozie
 OOZIE=/usr/bin/oozie
 
 # HDFS directory where Usmu files are copied to 
-USMU_HDFS_DIR=/cloudfeeds-nabu/usmu
+USMU_HDFS_DIR=/user/cloudfeeds/cloudfeeds-nabu/usmu
+
+# the top level directory where success.txt file is written on successful run of
+# the daily workflow. The actual success.txt file will be placed inside subdirectories
+# of region and date. For example: success.txt file for DFW run on April 22, 2015
+# will be located in:
+#   ${USMU_SUCCESS_DIR}/DFW/2015-04-22
+USMU_SUCCESS_DIR=/user/cloudfeeds/cloudfeeds-nabu/usmu/run
 
 # HDFS parent directory where Postgres dumps from Cloud Feeds and Preferences Svc
 # DBs are stored. The Cloud Feeds dumps will be in the $FEEDS_DUMP_DIR directory
 # and the Preferences Svc dumps will be in $PREFS_DUMP_DIR
-POSTGRES_DUMP_DIR=/cloudfeeds
+POSTGRES_DUMP_DIR=/user/cloudfeeds
 FEEDS_DUMP_DIR=${POSTGRES_DUMP_DIR}/feeds_dump
 PREFS_DUMP_DIR=${POSTGRES_DUMP_DIR}/prefs_dump

--- a/usmu/src/main/resources/usmu-coordinator.xml
+++ b/usmu/src/main/resources/usmu-coordinator.xml
@@ -60,6 +60,10 @@
                  <name>hdfsDumpDir</name>
                  <value>${coord:dataIn('coordInput1')}</value>
              </property>
+             <property>
+                 <name>successDir</name>
+                 <value>${successDir}</value>
+             </property>
          </configuration>
       </workflow>
    </action>     


### PR DESCRIPTION
Changes to support a more seamless integration with Tiamat and to support monitoring:
* add a workflow fs action to create an empty ```success.txt``` file on successful run of the daily workflow
* add configuration for the top directory location in HDFS for the success file in the *.properties file
* change default values of some locations to /user/cloudfeeds