### PR TITLE
CF-836 Implement monitoring for Archiving apps

### DIFF
--- a/usmu/build.gradle
+++ b/usmu/build.gradle
@@ -78,6 +78,7 @@ ospackage {
         into install_path + '/bin'
         include 'usmu-*.sh'
         include '*.ddl'
+        include 'monitor-*.sh'
         // set permissions
         user app_user
         permissionGroup app_group

--- a/usmu/src/main/resources/monitor-feeds_dump.sh
+++ b/usmu/src/main/resources/monitor-feeds_dump.sh
@@ -1,0 +1,41 @@
+#!/bin/sh
+
+usage()
+{
+    echo "Usage: $0 <region>"
+    echo "where"
+    echo "  <region> is one of ORD, DFW, IAD, LON, SYD, HKG"
+    exit 1
+}
+
+if [ $# -lt 1 ]; then
+    usage
+fi
+region=$1
+
+# get current time in format H(0..23)MM(00..59)
+now=$(date +%k%M)
+
+# exit unless current time is in the right window
+if [ $now -lt 530 -o $now -gt 630 ]; then
+    echo "Time is not between 5:30 AM UTC and 6:30 AM UTC. Aborting."
+    exit 0
+fi
+
+# get yesterday date in YYYY-MM-DD format
+yesterday=`date -d "1 day ago" +%Y-%m-%d`
+
+# path to _SUCCESS file in hadoop filesystem
+success_file="/user/cloudfeeds/feeds_dump/$region/$yesterday/_SUCCESS"
+
+# test for file
+hadoop fs -test -e $success_file
+rc=$?
+
+if [ $rc -eq 0 ]; then
+    # SUCCESS
+    echo 0
+else
+    # FAILURE
+    echo 1
+fi

--- a/usmu/src/main/resources/monitor-feeds_dump.sh
+++ b/usmu/src/main/resources/monitor-feeds_dump.sh
@@ -17,8 +17,9 @@ region=$1
 now=$(date +%k%M)
 
 # exit unless current time is in the right window
-if [ $now -lt 530 -o $now -gt 630 ]; then
-    echo "Time is not between 5:30 AM UTC and 6:30 AM UTC. Aborting."
+if [ $now -lt 1000 -o $now -gt 1400 ]; then
+    echo "Time is not between 10:00 AM UTC and 2:00 PM UTC. Skipping checks."
+    echo 0
     exit 0
 fi
 
@@ -35,7 +36,9 @@ rc=$?
 if [ $rc -eq 0 ]; then
     # SUCCESS
     echo 0
+    exit 0
 else
     # FAILURE
     echo 1
+    exit 1
 fi

--- a/usmu/src/main/resources/monitor-feeds_dump.sh
+++ b/usmu/src/main/resources/monitor-feeds_dump.sh
@@ -18,7 +18,6 @@ now=$(date +%k%M)
 
 # exit unless current time is in the right window
 if [ $now -lt 1000 -o $now -gt 1400 ]; then
-    echo "Time is not between 10:00 AM UTC and 2:00 PM UTC. Skipping checks."
     echo 0
     exit 0
 fi

--- a/usmu/src/main/resources/monitor-prefs_dump.sh
+++ b/usmu/src/main/resources/monitor-prefs_dump.sh
@@ -5,7 +5,6 @@ now=$(date +%k%M)
 
 # exit unless current time is in the right window
 if [ $now -lt 1000 -o $now -gt 1400 ]; then
-    echo "Time is not between 10:00 AM UTC and 2:00 PM UTC. Skipping checks."
     echo 0
     exit 0
 fi

--- a/usmu/src/main/resources/monitor-prefs_dump.sh
+++ b/usmu/src/main/resources/monitor-prefs_dump.sh
@@ -1,0 +1,28 @@
+#!/bin/sh
+
+# get current time in format H(0..23)MM(00..59)
+now=$(date +%k%M)
+
+# exit unless current time is in the right window
+if [ $now -lt 530 -o $now -gt 630 ]; then
+    echo "Time is not between 5:30 AM UTC and 6:30 AM UTC. Aborting."
+    exit 0
+fi
+
+# get yesterday date in YYYY-MM-DD format
+yesterday=`date -d "1 day ago" +%Y-%m-%d`
+
+# path to _SUCCESS file in hadoop filesystem
+success_file="/user/cloudfeeds/prefs_dump/_$yesterday/_SUCCESS"
+
+# test for file
+hadoop fs -test -e $success_file
+rc=$?
+
+if [ $rc -eq 0 ]; then
+    # SUCCESS
+    echo 0
+else
+    # FAILURE
+    echo 1
+fi

--- a/usmu/src/main/resources/monitor-prefs_dump.sh
+++ b/usmu/src/main/resources/monitor-prefs_dump.sh
@@ -4,8 +4,9 @@
 now=$(date +%k%M)
 
 # exit unless current time is in the right window
-if [ $now -lt 530 -o $now -gt 630 ]; then
-    echo "Time is not between 5:30 AM UTC and 6:30 AM UTC. Aborting."
+if [ $now -lt 1000 -o $now -gt 1400 ]; then
+    echo "Time is not between 10:00 AM UTC and 2:00 PM UTC. Skipping checks."
+    echo 0
     exit 0
 fi
 
@@ -22,7 +23,9 @@ rc=$?
 if [ $rc -eq 0 ]; then
     # SUCCESS
     echo 0
+    exit 0
 else
     # FAILURE
     echo 1
+    exit 1
 fi

--- a/usmu/src/main/resources/monitor-usmu.sh
+++ b/usmu/src/main/resources/monitor-usmu.sh
@@ -1,0 +1,41 @@
+#!/bin/sh
+
+usage()
+{
+    echo "Usage: $0 <region>"
+    echo "where"
+    echo "  <region> is one of ORD, DFW, IAD, LON, SYD, HKG"
+    exit 1
+}
+
+if [ $# -lt 1 ]; then
+    usage
+fi
+region=$1
+
+# get current time in format H(0..23)MM(00..59)
+now=$(date +%k%M)
+
+# exit unless current time is in the right window
+if [ $now -lt 530 -o $now -gt 630 ]; then
+    echo "Time is not between 5:30 AM UTC and 6:30 AM UTC. Aborting."
+    exit 0
+fi
+
+# get yesterday date in YYYY-MM-DD format
+yesterday=`date -d "1 day ago" +%Y-%m-%d`
+
+# path to success.txt file in hadoop filesystem
+success_file="/user/cloudfeeds/cloudfeeds-nabu/usmu/run/$region/$yesterday/success.txt"
+
+# test for file
+hadoop fs -test -e $success_file
+rc=$?
+
+if [ $rc -eq 0 ]; then
+    # SUCCESS
+    echo 0
+else
+    # FAILURE
+    echo 1
+fi

--- a/usmu/src/main/resources/monitor-usmu.sh
+++ b/usmu/src/main/resources/monitor-usmu.sh
@@ -17,8 +17,9 @@ region=$1
 now=$(date +%k%M)
 
 # exit unless current time is in the right window
-if [ $now -lt 530 -o $now -gt 630 ]; then
-    echo "Time is not between 5:30 AM UTC and 6:30 AM UTC. Aborting."
+if [ $now -lt 1400 -o $now -gt 1800 ]; then
+    echo "Time is not between 2:00 PM UTC and 6:00 PM UTC. Skipping checks."
+    echo 0
     exit 0
 fi
 
@@ -35,7 +36,9 @@ rc=$?
 if [ $rc -eq 0 ]; then
     # SUCCESS
     echo 0
+    exit 0
 else
     # FAILURE
     echo 1
+    exit 1
 fi

--- a/usmu/src/main/resources/monitor-usmu.sh
+++ b/usmu/src/main/resources/monitor-usmu.sh
@@ -18,7 +18,6 @@ now=$(date +%k%M)
 
 # exit unless current time is in the right window
 if [ $now -lt 1400 -o $now -gt 1800 ]; then
-    echo "Time is not between 2:00 PM UTC and 6:00 PM UTC. Skipping checks."
     echo 0
     exit 0
 fi


### PR DESCRIPTION
Add monitor shell scripts for hadoop success files for 
* feeds dump from ballista (monitor-feeds_dump.sh),
* preference service dump from ballista (monitor-prefs_dump.sh), and 
* usmu processing run (monitor-usmu.sh)

monitor-feeds_dump.sh and monitor-usmu.sh requires a region (DFW, ORD, IAD, LON, HKG, SYD), while monitor-prefs_dump.sh does not.  All three will check for the success file of yesterday run, if the shell script is executed within a time window.

The monitor-prefs_dump.sh is written with the assumption that the success file will be stored in the hadoop fs path "/user/cloudfeeds/prefs_dump/_$yesterday/_SUCCESS" (note the underscore before $yesterday date value), which will be played in the near future.  

See Greg's comment in the Archiving Monitoring and Alerting wiki:
https://one.rackspace.com/display/cloudfeeds/Archiving+Monitoring+and+Alerting?focusedCommentId=127133310#comment-127133310

Also see the *Success File Locations* section in the wiki to validate the path:
https://one.rackspace.com/display/cloudfeeds/Archiving+Monitoring+and+Alerting?focusedCommentId=127133310#ArchivingMonitoringandAlerting-SuccessFileLocations