### PR TITLE
CF-721: set self/prev/next archive links to point to Feeds endpoints

### DIFF
--- a/tiamat/src/main/scala/com/rackspace/feeds/archives/CreateFilesFeed.scala
+++ b/tiamat/src/main/scala/com/rackspace/feeds/archives/CreateFilesFeed.scala
@@ -34,6 +34,13 @@ object CreateFilesFeed {
 
   val feedUpdateTime = ISODateTimeFormat.dateTime().print( (new DateTime).withZone( DateTimeZone.UTC ))
 
+  def getNastIdAndContainerName(container : String): (String, String) = {
+    assert(container != null, "getNastIdAndContainerName(): container parameter must not be null")
+    val uriParts = container.split("/")
+    assert(uriParts.length >= 2, "getNastIdAndContainerName(): container must contain 2 or more uri parts")
+    (uriParts.dropRight(1).last, uriParts.last)
+  }
+
   def getFileName( key : ArchiveKey, date : String ): String = {
 
     val feed_name = key.feed.replace("/", "-")
@@ -193,16 +200,18 @@ object CreateFilesFeed {
     val next = getFileName( key, dayFormat.print( dateTime.minusDays( 1 ) ) )
     val prev = getFileName( key, dayFormat.print( dateTime.plusDays( 1 ) ) )
 
+    val (nastId, containerName) = getNastIdAndContainerName(container)
+
     s"""<?xml version="1.0" encoding="UTF-8" ?>
                   <feed xmlns="http://www.w3.org/2005/Atom"
                         xmlns:fh="http://purl.org/syndication/history/1.0">
         <fh:archive/>
         <link rel="current" href="${liveFeed}/${key.feed}/${getFeedId(key.tenantid, key.feed)}"/>
-        <link rel="self" href="${container}/${filename}"/>
+        <link rel="self" href="${liveFeed}/archive/${nastId}/${containerName}/${filename}"/>
         <id>${feedUuid}</id>
         <title type="text">${key.feed}</title>
-        <link rel="prev-archive" href="${container}/${prev}"/>
-        <link rel="next-archive" href="${container}/${next}"/>
+        <link rel="prev-archive" href="${liveFeed}/archive/${nastId}/${containerName}/${prev}"/>
+        <link rel="next-archive" href="${liveFeed}/archive/${nastId}/${containerName}/${next}"/>
         <updated>${feedUpdateTime}</updated>"""
   }
 

--- a/tiamat/src/main/scala/com/rackspace/feeds/archives/CreateFilesFeed.scala
+++ b/tiamat/src/main/scala/com/rackspace/feeds/archives/CreateFilesFeed.scala
@@ -39,7 +39,9 @@ object CreateFilesFeed {
     val url = new java.net.URL(container)
     assert(url.getPath != null, "getNastIdAndContainerName(): url must have path")
     val uriParts = url.getPath.split("/")
-    assert(uriParts.length >= 3, "getNastIdAndContainerName(): container must contain 2 or more uri parts")
+    // url.getPath() returns a path like this '/foo/bar/none'. 
+    // the first / is counted so the uriParts[0] is '', uriParts[1] is 'foo', etc
+    assert(uriParts.length >= 3, "getNastIdAndContainerName(): container url's path must contain 3 or more uri parts")
     (uriParts.dropRight(1).last, uriParts.last)
   }
 

--- a/tiamat/src/main/scala/com/rackspace/feeds/archives/CreateFilesFeed.scala
+++ b/tiamat/src/main/scala/com/rackspace/feeds/archives/CreateFilesFeed.scala
@@ -36,8 +36,10 @@ object CreateFilesFeed {
 
   def getNastIdAndContainerName(container : String): (String, String) = {
     assert(container != null, "getNastIdAndContainerName(): container parameter must not be null")
-    val uriParts = container.split("/")
-    assert(uriParts.length >= 2, "getNastIdAndContainerName(): container must contain 2 or more uri parts")
+    val url = new java.net.URL(container)
+    assert(url.getPath != null, "getNastIdAndContainerName(): url must have path")
+    val uriParts = url.getPath.split("/")
+    assert(uriParts.length >= 3, "getNastIdAndContainerName(): container must contain 2 or more uri parts")
     (uriParts.dropRight(1).last, uriParts.last)
   }
 

--- a/tiamat/src/test/scala/com.rackspace.feeds.archives/CreateFilesFeedTest.scala
+++ b/tiamat/src/test/scala/com.rackspace.feeds.archives/CreateFilesFeedTest.scala
@@ -25,18 +25,18 @@ class CreateFilesFeedTest extends FunSuite {
             xmlns:fh="http://purl.org/syndication/history/1.0">
         <fh:archive/>
         <link rel="current" href="http://livefeed1/feed1/1234"/>
-        <link rel="self" href="container1/filename1"/>
+        <link rel="self" href="http://livefeed1/archive/1234_nast/container1/filename1"/>
         <id>uuid1</id>
         <title type="text">feed1</title>
-        <link rel="prev-archive" href="container1/region1_feed1_2014-02-19.xml"/>
-        <link rel="next-archive" href="container1/region1_feed1_2014-02-17.xml"/>
+        <link rel="prev-archive" href="http://livefeed1/archive/1234_nast/container1/region1_feed1_2014-02-19.xml"/>
+        <link rel="next-archive" href="http://livefeed1/archive/1234_nast/container1/region1_feed1_2014-02-17.xml"/>
         <updated>TIME</updated>"""
 
   test( "feedPreface() - feed preface should be correct for given tenant and feed" ) {
 
     val tenantPrefs = Map( "1234" -> TenantPrefs( "1234", "1234_nast", Map(), List( CreateFilesFeed.XML_KEY ) ) )
 
-    val preface = feedPreface( "container1",
+    val preface = feedPreface( "http://cloudfiles/v1/1234_nast/container1",
       "filename1",
       ArchiveKey( "1234", "region1", "feed1", "2014-02-18", XML_KEY  ),
       makeNastIdToTenantMap( tenantPrefs, Set() ),
@@ -54,16 +54,16 @@ class CreateFilesFeedTest extends FunSuite {
             xmlns:fh="http://purl.org/syndication/history/1.0">
         <fh:archive/>
         <link rel="current" href="http://livefeed1/feed1/1234_nast"/>
-        <link rel="self" href="container1/filename1"/>
+        <link rel="self" href="http://livefeed1/archive/1234_nast/container1/filename1"/>
         <id>uuid1</id>
         <title type="text">feed1</title>
-        <link rel="prev-archive" href="container1/region1_feed1_2014-02-19.xml"/>
-        <link rel="next-archive" href="container1/region1_feed1_2014-02-17.xml"/>
+        <link rel="prev-archive" href="http://livefeed1/archive/1234_nast/container1/region1_feed1_2014-02-19.xml"/>
+        <link rel="next-archive" href="http://livefeed1/archive/1234_nast/container1/region1_feed1_2014-02-17.xml"/>
         <updated>TIME</updated>"""
 
     val tenantPrefs = Map( "1234" -> TenantPrefs( "1234", "1234_nast", Map(), List( CreateFilesFeed.XML_KEY ) ) )
 
-    val preface = feedPreface( "container1",
+    val preface = feedPreface( "http://cloudfiles/v1/1234_nast/container1",
       "filename1",
       ArchiveKey( "1234", "region1", "feed1", "2014-02-18", XML_KEY  ),
       makeNastIdToTenantMap( tenantPrefs, Set( "feed1" ) ),
@@ -279,7 +279,7 @@ class CreateFilesFeedTest extends FunSuite {
 
   test( "generateJson() - with events" ) {
 
-    val protoJson= """{"feed" : {"@type": "http://www.w3.org/2005/Atom", "link" : [{"rel" : "current","href" : "http://livefeed1/feed1/1234"}, {"rel" : "self","href" : "container1/filename1"}, {"rel" : "prev-archive","href" : "container1/region1_feed1_2014-02-19.xml"}, {"rel" : "next-archive","href" : "container1/region1_feed1_2014-02-17.xml"}],"archive" :{ "@type" : "http://purl.org/syndication/history/1.0" }, "id" : "uuid1", "title" : {"type" : "text", "@text" : "feed1"}, "updated" : "TIME", "entry": [{
+    val protoJson= """{"feed" : {"@type": "http://www.w3.org/2005/Atom", "link" : [{"rel" : "current","href" : "http://livefeed1/feed1/1234"}, {"rel" : "self","href" : "http://livefeed1/archive/1234_nast/container1/filename1"}, {"rel" : "prev-archive","href" : "http://livefeed1/archive/1234_nast/container1/region1_feed1_2014-02-19.xml"}, {"rel" : "next-archive","href" : "http://livefeed1/archive/1234_nast/container1/region1_feed1_2014-02-17.xml"}],"archive" :{ "@type" : "http://purl.org/syndication/history/1.0" }, "id" : "uuid1", "title" : {"type" : "text", "@text" : "feed1"}, "updated" : "TIME", "entry": [{
                      |        "category": [
                      |            {
                      |                "term": "tid:1234"
@@ -397,7 +397,7 @@ class CreateFilesFeedTest extends FunSuite {
 
   test( "generateJson() - empty feed" ) {
 
-    val protoJson= """{"feed" : {"@type": "http://www.w3.org/2005/Atom", "link" : [{"rel" : "current","href" : "http://livefeed1/feed1/1234"}, {"rel" : "self","href" : "container1/filename1"}, {"rel" : "prev-archive","href" : "container1/region1_feed1_2014-02-19.xml"}, {"rel" : "next-archive","href" : "container1/region1_feed1_2014-02-17.xml"}],"archive" :{ "@type" : "http://purl.org/syndication/history/1.0" }, "id" : "uuid1", "title" : {"type" : "text", "@text" : "feed1"}, "updated" : "TIME"}}""".stripMargin
+    val protoJson= """{"feed" : {"@type": "http://www.w3.org/2005/Atom", "link" : [{"rel" : "current","href" : "http://livefeed1/feed1/1234"}, {"rel" : "self","href" : "http://livefeed1/archive/1234_nast/container1/filename1"}, {"rel" : "prev-archive","href" : "http://livefeed1/archive/1234_nast/container1/region1_feed1_2014-02-19.xml"}, {"rel" : "next-archive","href" : "http://livefeed1/archive/1234_nast/container1/region1_feed1_2014-02-17.xml"}],"archive" :{ "@type" : "http://purl.org/syndication/history/1.0" }, "id" : "uuid1", "title" : {"type" : "text", "@text" : "feed1"}, "updated" : "TIME"}}""".stripMargin
 
     val output = new ByteArrayOutputStream()
 
@@ -418,11 +418,11 @@ class CreateFilesFeedTest extends FunSuite {
                   |            xmlns:fh="http://purl.org/syndication/history/1.0">
                   |        <fh:archive/>
                   |        <link rel="current" href="http://livefeed1/feed1/1234"/>
-                  |        <link rel="self" href="container1/filename1"/>
+                  |        <link rel="self" href="http://livefeed1/archive/1234_nast/container1/filename1"/>
                   |        <id>uuid1</id>
                   |        <title type="text">feed1</title>
-                  |        <link rel="prev-archive" href="container1/region1_feed1_2014-02-19.xml"/>
-                  |        <link rel="next-archive" href="container1/region1_feed1_2014-02-17.xml"/>
+                  |        <link rel="prev-archive" href="http://livefeed1/archive/1234_nast/container1/region1_feed1_2014-02-19.xml"/>
+                  |        <link rel="next-archive" href="http://livefeed1/archive/1234_nast/container1/region1_feed1_2014-02-17.xml"/>
                   |        <updated>TIME</updated><atom:entry xmlns:usage-summary="http://docs.rackspace.com/core/usage-summary"
                   |            xmlns:wadl="http://wadl.dev.java.net/2009/02"
                   |            xmlns:d312e1="http://wadl.dev.java.net/2009/02"
@@ -528,11 +528,11 @@ class CreateFilesFeedTest extends FunSuite {
                   |            xmlns:fh="http://purl.org/syndication/history/1.0">
                   |        <fh:archive/>
                   |        <link rel="current" href="http://livefeed1/feed1/1234"/>
-                  |        <link rel="self" href="container1/filename1"/>
+                  |        <link rel="self" href="http://livefeed1/archive/1234_nast/container1/filename1"/>
                   |        <id>uuid1</id>
                   |        <title type="text">feed1</title>
-                  |        <link rel="prev-archive" href="container1/region1_feed1_2014-02-19.xml"/>
-                  |        <link rel="next-archive" href="container1/region1_feed1_2014-02-17.xml"/>
+                  |        <link rel="prev-archive" href="http://livefeed1/archive/1234_nast/container1/region1_feed1_2014-02-19.xml"/>
+                  |        <link rel="next-archive" href="http://livefeed1/archive/1234_nast/container1/region1_feed1_2014-02-17.xml"/>
                   |        <updated>TIME</updated></feed>""".stripMargin
 
     val output = new ByteArrayOutputStream()
@@ -541,4 +541,9 @@ class CreateFilesFeedTest extends FunSuite {
 
     assert( output.toString().replaceAll( "\\s+", " ") == proto.replaceAll( "\\s+", " " ) )
   }
+
+    val containerUrl = "https://hostname/v1/nastId/myContainer/"
+    test( "should get the right container name on url: " + containerUrl) {
+        assert(getNastIdAndContainerName(containerUrl) == ("nastId", "myContainer"))
+    }
 }

--- a/tiamat/src/test/scala/com.rackspace.feeds.archives/CreateFilesFeedTest.scala
+++ b/tiamat/src/test/scala/com.rackspace.feeds.archives/CreateFilesFeedTest.scala
@@ -542,8 +542,30 @@ class CreateFilesFeedTest extends FunSuite {
     assert( output.toString().replaceAll( "\\s+", " ") == proto.replaceAll( "\\s+", " " ) )
   }
 
-    val containerUrl = "https://hostname/v1/nastId/myContainer/"
-    test( "should get the right container name on url: " + containerUrl) {
-        assert(getNastIdAndContainerName(containerUrl) == ("nastId", "myContainer"))
-    }
+    val containerUrls = List( "https://hostname/v1/nastId/myContainer/",
+                              "https://hostname/v2/nastId/myContainer" )
+    containerUrls.foreach ( url =>
+        test( "should get the right container name on url: " + url) {
+            assert(getNastIdAndContainerName(url) == ("nastId", "myContainer"))
+        }
+    )
+
+    val invalidUrls = List ( "some_invalid_urls", "sftp:/incomplete" )
+    invalidUrls.foreach ( url =>
+        test ( "should get MalformedURL on url: " + url) {
+            intercept[java.net.MalformedURLException] {
+                getNastIdAndContainerName(url)
+            }
+        }
+    )
+
+    val invalidContainerUrls = List ( "http://hostname/not_enough_parts" )
+    invalidContainerUrls.foreach ( url =>
+        test ( "should get AssertionError on url: " + url) {
+            intercept[AssertionError] {
+                getNastIdAndContainerName(url)
+            }
+        }
+    )
+
 }


### PR DESCRIPTION
The changes are:
When we build archived pages in customers' Cloud Files containers, we currently set the self, prev-archive, and next-archive links to the container URLs that are specified in the customers' Preferences. We want to replace this with Cloud Feeds endpoints https://feeds.endpoints/archive/nastId/containerName.

