### PR TITLE
[CF-889] Require additional options to process all tenants

### DIFF
--- a/tiamat/src/main/scala/com/rackspace/feeds/archives/Options.scala
+++ b/tiamat/src/main/scala/com/rackspace/feeds/archives/Options.scala
@@ -111,7 +111,7 @@ class Options {
         c.copy(tenantIds = x)
       } text ("List of tenant IDs (comma-separated). Mutually exclusive with option --all-tenants")
 
-      opt[Unit]("all-tenants") action { (x, c) =>
+      opt[Unit]('a', "all-tenants") action { (x, c) =>
         c.copy(isProcessAllTenants = true)
       } text ("all-tenants flag indicates whether to run for all tenants or not. Mutually exclusive with option --tenants")
 
@@ -131,12 +131,12 @@ class Options {
 
     //if both options are used
     if (rc.isProcessAllTenants && rc.tenantIds.nonEmpty) {
-      throw new IllegalArgumentException( "Invalid command line options. --all-tenants and -tenants cannot be given at the same time")
+      throw new IllegalArgumentException( "Invalid command line options.--all-tenants (-a) and --tenants (-t) cannot be given at the same time")
     }
 
     //if neither options are used
     if (!rc.isProcessAllTenants && rc.tenantIds.isEmpty) {
-      throw new IllegalArgumentException( "Invalid command line options. One of --all-tenants or -tenants must be given. ")
+      throw new IllegalArgumentException( "Invalid command line options. One of --all-tenants (-a) or --tenants (-t) must be given. ")
     }
 
     val rc1 = processDates(rc)

--- a/tiamat/src/main/scala/com/rackspace/feeds/archives/Options.scala
+++ b/tiamat/src/main/scala/com/rackspace/feeds/archives/Options.scala
@@ -16,7 +16,8 @@ case class RunConfig( configPath : String = Options.CONF,
                       regions : Seq[String] = Seq[String](),
                       config : Config = ConfigFactory.empty(),
                       lastSuccessPath : String = Options.LAST_SUCCESS,
-                      skipSuccessFileCheck: Boolean = false) {
+                      skipSuccessFileCheck: Boolean = false,
+                      isProcessAllTenants: Boolean = false) {
 
   def getMossoFeeds() : Set[String] = {
 
@@ -108,8 +109,12 @@ class Options {
       opt[Seq[String]]('t', "tenants") action { (x, c) =>
 
         c.copy(tenantIds = x)
-      } text ("List of tenant IDs (comma-separated).  Default is all archiving-enabled tenants.")
-      
+      } text ("List of tenant IDs (comma-separated). Mutually exclusive with option --all-tenants")
+
+      opt[Unit]("all-tenants") action { (x, c) =>
+        c.copy(isProcessAllTenants = true)
+      } text ("all-tenants flag indicates whether to run for all tenants or not. Mutually exclusive with option --tenants")
+
       opt[Unit]("skipSuccessFileCheck") action { (x, c) =>
         c.copy(skipSuccessFileCheck = true)
       } text ("skipSuccessFileCheck flag is used to skip verification of existence of success files configured in success.paths property. ")
@@ -122,6 +127,16 @@ class Options {
 
       case Some(runConfig: RunConfig) => runConfig
       case _ => throw new Exception( "Invalid ")
+    }
+
+    //if both options are used
+    if (rc.isProcessAllTenants && rc.tenantIds.nonEmpty) {
+      throw new IllegalArgumentException( "Invalid command line options. --all-tenants and -tenants cannot be given at the same time")
+    }
+
+    //if neither options are used
+    if (!rc.isProcessAllTenants && rc.tenantIds.isEmpty) {
+      throw new IllegalArgumentException( "Invalid command line options. One of --all-tenants or -tenants must be given. ")
     }
 
     val rc1 = processDates(rc)

--- a/tiamat/src/test/scala/com.rackspace.feeds.archives/OptionsTest.scala
+++ b/tiamat/src/test/scala/com.rackspace.feeds.archives/OptionsTest.scala
@@ -38,7 +38,7 @@ class OptionsTest extends FunSuite {
   test("No feeds option produces default feeds") {
 
     val options = new Options()
-    val config = options.parseOptions( Array("-c", getConf() ) )
+    val config = options.parseOptions( Array("-c", getConf(), "--all-tenants") )
     val feeds = getFeeds(config)
 
     assert( feeds &~ config.feeds.toSet isEmpty )
@@ -74,7 +74,7 @@ class OptionsTest extends FunSuite {
   test("Default regions") {
 
     val options = new Options()
-    val config = options.parseOptions( Array("-c", getConf() ) )
+    val config = options.parseOptions( Array("-c", getConf(), "--all-tenants" ) )
 
     assert( Set( "dfw","iad","hkg", "lon","ord", "syd" ) &~ config.regions.toSet isEmpty )
   }
@@ -83,8 +83,34 @@ class OptionsTest extends FunSuite {
 
     val options = new Options()
     intercept[ConfigException] {
-      val config = options.parseOptions( Array("-c", getConf( "src/test/resources/bad.conf" ) ) )
+      val config = options.parseOptions( Array("-c", getConf( "src/test/resources/bad.conf" ), "--all-tenants" ) )
     }
+  }
+
+  test("No tenants configured") {
+
+    val options = new Options()
+
+    intercept[IllegalArgumentException] {
+      val config = options.parseOptions( Array("-c", getConf() ))
+    }
+  }
+
+  test("Invalid tenants configured") {
+
+    val options = new Options()
+
+    intercept[IllegalArgumentException] {
+      val config = options.parseOptions( Array("-c", getConf(), "--all-tenants", "--tenants", "12345,67890" ))
+    }
+  }
+
+  test("Process all tenants") {
+
+    val options = new Options()
+    val config = options.parseOptions( Array("-c", getConf(), "--all-tenants" ) )
+
+    assert( config.isProcessAllTenants == true )
   }
 
   test( "Test happy path configuration" ) {
@@ -108,12 +134,13 @@ class OptionsTest extends FunSuite {
     assert( tids &~ config.tenantIds.toSet isEmpty )
     assert( regs &~ config.regions.toSet isEmpty )
     assert( dates &~ config.dates.toSet isEmpty )
-    assert(config.skipSuccessFileCheck == false)
+    assert( config.skipSuccessFileCheck == false)
+    assert( config.isProcessAllTenants == false)
   }
 
   test("skip success file check") {
     val options = new Options()
-    val config = options.parseOptions( Array("-c", getConf(), "--skipSuccessFileCheck") )
+    val config = options.parseOptions( Array("-c", getConf(), "--skipSuccessFileCheck", "--all-tenants") )
 
     assert(config.skipSuccessFileCheck == true)
   }

--- a/tiamat/src/test/scala/com.rackspace.feeds.archives/OptionsTest.scala
+++ b/tiamat/src/test/scala/com.rackspace.feeds.archives/OptionsTest.scala
@@ -38,7 +38,7 @@ class OptionsTest extends FunSuite {
   test("No feeds option produces default feeds") {
 
     val options = new Options()
-    val config = options.parseOptions( Array("-c", getConf(), "--all-tenants") )
+    val config = options.parseOptions( Array("-c", getConf(), "-a") )
     val feeds = getFeeds(config)
 
     assert( feeds &~ config.feeds.toSet isEmpty )


### PR DESCRIPTION
  - Added option --all-tenants to process all tenants
  - Options --all-tenants and --tenants are mutually exclusive and atleast one of them have to be present.