### PR TITLE
CF-1032: make this script idempotent

### DIFF
--- a/usmu/src/main/resources/entries.hive.ddl
+++ b/usmu/src/main/resources/entries.hive.ddl
@@ -4,7 +4,7 @@
 -- This MUST match with how the Spark job is reading
 -- the table.
 
-CREATE TABLE entries(
+CREATE TABLE IF NOT EXISTS entries(
        id bigint,
        entryid string,
        creationdate timestamp,


### PR DESCRIPTION
This script is now being run on the deployment. Which means, if the table to be created already exists, it should not fail.