### PR TITLE
NULL values in db solution, update tiamat reference.conf

### DIFF
--- a/tiamat/src/main/resources/reference.conf
+++ b/tiamat/src/main/resources/reference.conf
@@ -13,12 +13,6 @@ tiamat {
 
   feeds.liveUri {
 
-    dfw = "X"
-    iad = "X"
-    hkg = "X"
-    lon = "X"
-    ord = "X"
-    syd = "X"
   }
 
   feeds.MossoId = [

--- a/tiamat/src/main/scala/com/rackspace/feeds/archives/Archiver.scala
+++ b/tiamat/src/main/scala/com/rackspace/feeds/archives/Archiver.scala
@@ -354,15 +354,31 @@ object Archiver {
 
   def toEntry( row : Row ) : Entry = {
 
-    Entry( row.getString( 0 ),
-      row.getString( 1 ),
-      row.getString( 2 ),
-      row.getString( 3 ),
+    Entry(  getStringValue( row, 0 ),
+      getStringValue( row, 1 ),
+      getStringValue( row, 2 ),
+      getStringValue( row, 3 ),
       row( 4 ).asInstanceOf[Timestamp],
       row.getLong( 5 ),
-      row.getString( 6 ),
-      row.getString( 7 )
+      getStringValue( row, 6 ),
+      getStringValue( row, 7 )
     )
+  }
+
+  /**
+   * TODO:  This was added to prevent tiamat from breaking when any of the string values are null.  I added this when
+   * we were getting ready for our demo, and something a bit more intelligent needs to happen.
+   *
+   * @param row
+   * @param i
+   * @return
+   */
+  def getStringValue( row: Row, i : Int ) : String = {
+
+    if( row.isNullAt( i ) )
+      ""
+    else
+      row.getString( i )
   }
 
   /**

--- a/tiamat/src/main/scala/com/rackspace/feeds/archives/Archiver.scala
+++ b/tiamat/src/main/scala/com/rackspace/feeds/archives/Archiver.scala
@@ -354,6 +354,13 @@ object Archiver {
 
   def toEntry( row : Row ) : Entry = {
 
+    /*
+     * No values should be null, but doing this in case anything slips through.  We've found that entrytype
+     * has been null in the past, so I'm handling the case for all string values.
+     *
+     * id & timestamp are never null as per our postgres schema.
+     */
+
     Entry(  getStringValue( row, 0 ),
       getStringValue( row, 1 ),
       getStringValue( row, 2 ),
@@ -366,8 +373,7 @@ object Archiver {
   }
 
   /**
-   * TODO:  This was added to prevent tiamat from breaking when any of the string values are null.  I added this when
-   * we were getting ready for our demo, and something a bit more intelligent needs to happen.
+   * This was added to prevent tiamat from breaking when any of the string values are null.
    *
    * @param row
    * @param i


### PR DESCRIPTION
Two fixes:
- removing list of regions from the reference.conf to allow tiamat to run environments with fewer regions (e.g., test & staging)
- updating tiamat to handle null values in any string fields in the db (all non-string fields will never be null as per postgres schema).

NOTE:  Some string fields are declared as NOT NULL in postgress and don't need the check, but i added anyway.   Let me know if you want to remove it.