### PR TITLE
turn off console logging for Tiamat

### DIFF
--- a/tiamat/src/main/resources/log4j.properties
+++ b/tiamat/src/main/resources/log4j.properties
@@ -1,8 +1,4 @@
-log4j.rootCategory=INFO, console, file
-log4j.appender.console=org.apache.log4j.ConsoleAppender
-log4j.appender.console.target=System.err
-log4j.appender.console.layout=org.apache.log4j.PatternLayout
-log4j.appender.console.layout.ConversionPattern=%d{yy/MM/dd HH:mm:ss} %p %c{1}: %m%n
+log4j.rootCategory=INFO, file
 
 log4j.appender.file=org.apache.log4j.DailyRollingFileAppender
 log4j.appender.file.layout=org.apache.log4j.PatternLayout


### PR DESCRIPTION
When you run Tiamat manually, you will see logging going out to stdout. I don't think this is useful as things scroll by fast on the screen and I can't search for a specific things. 

When you run Tiamat from cron, cron will save all the output and mail it to the user. As a result, cloudfeeds user will get email everytime Tiamat runs. This may be flooding cloudfeeds user mailbox. Someone has to remember to delete those emails.

So this PR turns off console logging :-) for Tiamat.