### PR TITLE
CF-1054: expect 202 from Files

### DIFF
--- a/tiamat/src/main/scala/com/rackspace/feeds/archives/CreateFilesFeed.scala
+++ b/tiamat/src/main/scala/com/rackspace/feeds/archives/CreateFilesFeed.scala
@@ -244,6 +244,7 @@ object CreateFilesFeed {
     resp.getStatusLine.getStatusCode match {
 
       case 201 => ()
+      case 202 => ()
       case _ => throw new RestException(resp.getStatusLine.getStatusCode,
         CREATE_CONTAINER( uri, Source.fromInputStream(resp.getEntity.getContent).mkString ) )
     }

--- a/tiamat/src/main/scala/com/rackspace/feeds/archives/CreateFilesFeed.scala
+++ b/tiamat/src/main/scala/com/rackspace/feeds/archives/CreateFilesFeed.scala
@@ -116,6 +116,7 @@ object CreateFilesFeed {
     resp.getStatusLine.getStatusCode match {
 
       case 201 => ()
+      case 202 => ()
       case _ => throw new RestException(resp.getStatusLine.getStatusCode,
         WRITE( path, Source.fromInputStream(resp.getEntity.getContent).mkString ) )
     }


### PR DESCRIPTION
According to Cloud Files documentation here:
http://docs-internal.rackspace.com/files/api/v1/cf-devguide/content/PUT_createcontainer_v1__account___container__containerServicesOperations_d1e000.html

it's possible Cloud Files will return HTTP code 202 when the container to be created is already there.