### PR TITLE
CF-1053: clean up tiamat log

### DIFF
--- a/tiamat/src/main/resources/tiamat.sh
+++ b/tiamat/src/main/resources/tiamat.sh
@@ -4,5 +4,5 @@ SPARK_HOME=/usr/hdp/2.2.0.0-2041/spark
 TIAMAT_HOME=/opt/cloudfeeds-nabu/tiamat
 
 ${SPARK_HOME}/bin/spark-submit --class com.rackspace.feeds.archives.Tiamat \
-   --conf "spark.driver.extraJavaOptions=-Dlog4j.configuration=file:/etc/cloudfeeds-nabu/tiamat/log4j.properties" \
+   --driver-java-options "-Dlog4j.configuration=file:///etc/cloudfeeds-nabu/tiamat/log4j.properties" \
    --master yarn-client ${TIAMAT_HOME}/lib/cloudfeeds-nabu-tiamat.jar "$@"

--- a/tiamat/src/main/scala/com/rackspace/feeds/archives/Tiamat.scala
+++ b/tiamat/src/main/scala/com/rackspace/feeds/archives/Tiamat.scala
@@ -74,7 +74,7 @@ object Tiamat {
     }
     catch {
       case th : Throwable => {
-        logger.error(th.getMessage)
+        logger.error("Got throwable: ", th)
 
         throw th
       }


### PR DESCRIPTION
This mechanism of overwriting the log configuration for Spark:
```
--conf "spark.driver.extraJavaOptions=-Dlog4j.configuration=file:/etc/cloudfeeds-nabu/tiamat/log4j.properties"
```
does not work on HDP 2.2.4 and HDP 2.2.6.

I found this article in StackOverflow:
http://stackoverflow.com/questions/28840438/how-to-override-sparks-log4j-properties-per-driver/31565963#31565963

The option ```   --driver-java-options "-Dlog4j.configuration=file:///etc/cloudfeeds-nabu/tiamat/log4j.properties"``` works great! I tested it in both HDP 2.2.4 and HDP 2.2.6.

The only thing that's a bit weird is that when you run tiamat and tiamat got an error, the stack trace is printed out to stdout/stderr (not logging). Like this:
```
[cloudfeeds@gateway-1 bin]$  sh tiamat.sh --dates 2015-07-22 -t 5914283
Spark assembly has been built with Hive, including Datanucleus jars on classpath
Exception in thread "main" java.lang.RuntimeException: TIAMAT008: Missing success files: [/user/cloudfeeds/cloudfeeds-nabu/usmu/run/ord/2015-07-22/success.txt,/user/cloudfeeds/prefs_dump/_2015-07-22/_SUCCESS]
	at com.rackspace.feeds.archives.Archiver.validateSuccessFilePaths(Archiver.scala:128)
	at com.rackspace.feeds.archives.Archiver.run(Archiver.scala:95)
	at com.rackspace.feeds.archives.Tiamat$.main(Tiamat.scala:72)
	at com.rackspace.feeds.archives.Tiamat.main(Tiamat.scala)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:57)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:606)
	at org.apache.spark.deploy.SparkSubmit$.launch(SparkSubmit.scala:360)
	at org.apache.spark.deploy.SparkSubmit$.main(SparkSubmit.scala:76)
	at org.apache.spark.deploy.SparkSubmit.main(SparkSubmit.scala)
```
In the tiamat.log, I only see this:
```
15/07/22 14:40:22 ERROR Archiver: TIAMAT008: Missing success files: [/user/cloudfeeds/cloudfeeds-nabu/usmu/run/ord/2015-07-22/success.txt,/user/cloudfeeds/prefs_dump/_2015-07-22/_SUCCESS]
15/07/22 14:40:22 ERROR Tiamat$: TIAMAT008: Missing success files: [/user/cloudfeeds/cloudfeeds-nabu/usmu/run/ord/2015-07-22/success.txt,/user/cloudfeeds/prefs_dump/_2015-07-22/_SUCCESS]
```
No exception stack trace.

So the 2nd edit to Tiamat.scala in this PR is to make it so that we log the exception stack trace in log file as well. 

I don't know how to suppress the Exception stack trace from the stdout. Tiamat.scala throws the exception from main. I don't think I can change this to not throw the exception. I think this exception is then printed by the spark-submit CLI. 
 