### PR TITLE
CF-1105 - add --test-run switch to tiamat to enable testing

### DIFF
--- a/tiamat/src/main/resources/reference.conf
+++ b/tiamat/src/main/resources/reference.conf
@@ -26,4 +26,12 @@ tiamat {
   success.file.paths = [
     "X"
   ]
+
+  feeds.Test = [
+    "X"
+  ]
+
+  tenants.Test = [
+    "X"
+  ]
 }

--- a/tiamat/src/main/resources/tiamat.conf
+++ b/tiamat/src/main/resources/tiamat.conf
@@ -59,4 +59,18 @@ tiamat {
     "/user/cloudfeeds/cloudfeeds-nabu/usmu/run/#REGION#/#RUNDATE#/success.txt" # USMU success file path
     "/user/cloudfeeds/prefs_dump/_#RUNDATE#/_SUCCESS" # Ballista prefs success file path
   ]
+
+  #
+  # Feeds only archived during --test-run for test tenants  (All assumed to be MossoIds)
+  #
+  feeds.Test = [
+    "functest1/events"
+  ]
+
+  #
+  # Tenants only archived during --test-run for test tenants
+  #
+  tenants.Test = [
+    "test1"
+  ]
 }

--- a/tiamat/src/main/scala/com/rackspace/feeds/archives/Tiamat.scala
+++ b/tiamat/src/main/scala/com/rackspace/feeds/archives/Tiamat.scala
@@ -26,6 +26,12 @@ import scala.collection.JavaConverters
  *       List of regions (common-separated).  Default is all regions.
  * -t <value> | --tenants <value>
  *       List of tenant IDs (comma-separated).  Default is all archiving-enabled tenants.
+ * -a | --all-tenants
+ *       all-tenants flag indicates whether to run for all tenants or not. Mutually exclusive with option --tenants
+ * --skipSuccessFileCheck
+ *       skipSuccessFileCheck flag is used to skip verification of existence of success files configured in success.paths property.
+ * -z | --test-run
+ *       test-run flag indicates whether to run in test-mode, which writes to specific test tenants and writes a custom set of feeds only for these test tenants.
  * --help
  *       Show this.
  *

--- a/tiamat/src/test/resources/test.conf
+++ b/tiamat/src/test/resources/test.conf
@@ -30,4 +30,12 @@ tiamat {
     "/user/cloudfeeds/cloudfeeds-nabu/usmu/run/#REGION#/#RUNDATE#/success.txt" # USMU success file path
     "/user/cloudfeeds/prefs_dump/_#RUNDATE#/_SUCCESS" # Ballista prefs success file path
   ]
+
+  feeds.Test = [
+    "functest1/events"
+  ]
+
+  tenants.Test = [
+    "test1"
+  ]
 }

--- a/tiamat/src/test/scala/com.rackspace.feeds.archives/OptionsTest.scala
+++ b/tiamat/src/test/scala/com.rackspace.feeds.archives/OptionsTest.scala
@@ -152,9 +152,54 @@ class OptionsTest extends FunSuite {
 
     assert(config.skipSuccessFileCheck == true)
   }
-  
+
+  test( "run --test-run" ) {
+
+    val options = new Options()
+    val config = options.parseOptions( Array("-c", getConf(), "--test-run") )
+
+    assert( config.feeds.toSet &~ getTestFeeds( config ).toSet isEmpty )
+    assert( config.tenantIds.toSet &~ getTestTenants(config ).toSet isEmpty )
+  }
+
+  test( "run --test-run and --tenants" ) {
+
+    val options = new Options()
+    intercept[IllegalArgumentException] {
+      val config = options.parseOptions(Array("-c", getConf(), "--test-run", "--tenants", "tid1,tid2"))
+    }
+  }
+
+  test( "run --test-run and --all-tenants") {
+
+    val options = new Options()
+    intercept[IllegalArgumentException] {
+      val config = options.parseOptions(Array("-c", getConf(), "--test-run", "--all-tenants" ))
+    }
+  }
+
+  test( "run --test-run and --feeds" ) {
+
+    val options = new Options()
+    intercept[IllegalArgumentException] {
+      val config = options.parseOptions(Array("-c", getConf(), "--test-run", "--feeds", "feed1/events" ))
+    }
+
+  }
+
+
   def getFeeds( config : RunConfig ) : Set[String] = {
 
     config.getMossoFeeds() ++ config.getNastFeeds()
+  }
+
+  def getTestFeeds( config : RunConfig ) : List[String] = {
+
+    config.getTestFeeds()
+  }
+
+  def getTestTenants( config : RunConfig ) : List[String] = {
+
+    config.getTestTenants()
   }
 }


### PR DESCRIPTION
I'll also have a PR to our ansible project to update the tiamat.conf generation to add the new test-related fields.