### PR TITLE
CF-1186: kill coordinator jobs only with certain names (ours)

### DIFF
--- a/usmu/src/main/resources/usmu-coord-run.sh
+++ b/usmu/src/main/resources/usmu-coord-run.sh
@@ -33,13 +33,13 @@ if [ ! -f ${COORDINATOR_PROPS} ]; then
 fi
 source ${COORDINATOR_PROPS}
 
-# There doesn't seem to be a nicer way to find existing Oozie jobs so
-# we can kill and submit a new set. This one I found on the web and
-# probably needs to be evaluated every time we upgrade Oozie.
-
 # Clean up previous run. 
-# WARNING: this WILL delete *all* RUNNING jobs.
-curl ${OOZIE_URL}'/v1/jobs?len=1000&filter=status%3DRUNNING&jobtype=coord'  | python -mjson.tool | grep "coordJobId" | sed "s/\(.*\)coordJobId\(.*\): \"\(.*\)\"\(.*\)/\3/" | while read job_id; do oozie job -oozie ${OOZIE_URL} -kill $job_id; done
+
+`dirname $0`/usmu-coord-stop.sh
+if [ $? -ne 0 ]; then
+    echo "WARN: unable to stop/kill previous coordinator jobs."
+    echo "Please do so manually."
+fi
 
 # run the usmu-coordinator.xml for each region to watch for Cloud Feeds dump
 for aRegion in ${REGION_LIST}

--- a/usmu/src/main/resources/usmu-coord-stop.sh
+++ b/usmu/src/main/resources/usmu-coord-stop.sh
@@ -1,15 +1,12 @@
 #!/bin/sh
 #
-# This script is used to deploy new versions of Usmu's Oozie Coordinator and Workflow.
-# It is a temporary script used during development, when we're updating coordinators
-# and workflows. This eventually needs to be part of the deployment script (Ansible,
-# etc)
+# This script is used to kill existing running Usmu's Oozie Coordinator and Workflow.
 #
 
 usage()
 {
-    echo "Usage: `basename $0` <startTime> <endTime>"
-    echo "where:"
+    # this is just a documentation of how to run this script
+    echo "Usage: `basename $0`"
     exit 1
 }
 
@@ -23,11 +20,13 @@ if [ ! -f ${COORDINATOR_PROPS} ]; then
 fi
 source ${COORDINATOR_PROPS}
 
-# There doesn't seem to be a nicer way to find existing Oozie jobs so
-# we can kill and submit a new set. This one I found on the web and
-# probably needs to be evaluated every time we upgrade Oozie.
-
 # Clean up previous run. 
-# WARNING: this WILL delete *all* RUNNING jobs.
-curl ${OOZIE_URL}'/v1/jobs?len=1000&filter=status%3DRUNNING&jobtype=coord'  | python -mjson.tool | grep "coordJobId" | sed "s/\(.*\)coordJobId\(.*\): \"\(.*\)\"\(.*\)/\3/" | while read job_id; do oozie job -oozie ${OOZIE_URL} -kill $job_id; done
-
+for region in $REGION_LIST
+do
+    jobId=`oozie jobs -oozie ${OOZIE_URL} -jobtype coordinator -filter "status=RUNNING;name=FeedsImport-$region" | grep FeedsImport-$region | awk '{print $1}'`
+    if [ "$jobId" != "" ]; then
+        echo "Stopping/kill job $jobId"
+        oozie job -oozie ${OOZIE_URL} -kill $jobId
+    fi
+done
+exit 0


### PR DESCRIPTION
Change script so that when we stop/kill previously running coordinator jobs, we only kill those jobs with the name FeedsImport-$region. The $region variable will come from the REGION_LIST in the usmu-coordinator.properties file.