### PR TITLE
CF-541 - Ensure Tiamat is kept in synch with standard-usage-schema

### DIFF
--- a/tiamat/build.gradle
+++ b/tiamat/build.gradle
@@ -147,6 +147,7 @@ artifacts {
         type   'rpm'
         builtBy buildRpm
     }
+    archives jar
 }
 
 uploadArchives {


### PR DESCRIPTION
Adding tiamat jar as artifact published to maven

After this is accepted I'd like to cut a new release of nabu so I could verify my usage-schema work against the published jar.