### PR TITLE
CF-541 - Ensure Tiamat is kept in synch with standard-usage-schema

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -170,9 +170,6 @@ artifacts {
 
     def tiamat_artifact = custom.parentProject + '-tiamat-' + project.version.minus('-SNAPSHOT') + '-1.noarch.rpm'
     archives file: file('tiamat/build/distributions/' + tiamat_artifact), name: tiamat_artifact, type: 'rpm', classifier: 'tiamat'
-
-    def tiamat_jar = custom.parentProject + '-tiamat-' + project.version.minus('-SNAPSHOT') + '-all.jar'
-    archives file: file('tiamat/build/libs/' + tiamat_jar), name: tiamat_jar, type: 'jar', classifier: 'tiamat'
 }
 
 uploadArchives {

--- a/tiamat/build.gradle
+++ b/tiamat/build.gradle
@@ -147,7 +147,6 @@ artifacts {
         type   'rpm'
         builtBy buildRpm
     }
-    archives jar
 }
 
 uploadArchives {

--- a/tiamat/src/main/resources/rm_private_attrs_for_obs.xsl
+++ b/tiamat/src/main/resources/rm_private_attrs_for_obs.xsl
@@ -28,18 +28,18 @@
 
     <!--For product: CloudServers -->
     <xsl:template xmlns:pf="http://docs.rackspace.com/event/servers/slice"
-                 match="pf:product[@version='1']/@*[some $x in ('rootPassword', 'options', 'huddleId', 'serverId', 'customerId', 'flavorId', 'sliceType', 'privateIp') satisfies $x eq local-name(.)]"
+                 match="pf:product[@version='1']/@*[some $x in ('customerId', 'flavorId', 'huddleId', 'options', 'privateIp', 'rootPassword', 'serverId', 'sliceType') satisfies $x eq local-name(.)]"
                  mode="rm_priv"/>
    <xsl:template xmlns:pf="http://docs.rackspace.com/event/servers/hostserver"
-                 match="pf:product[@version='1']/@*[some $x in ('coreID', 'huddleID', 'backstageURL') satisfies $x eq local-name(.)]"
+                 match="pf:product[@version='1']/@*[some $x in ('backstageURL', 'coreID', 'huddleID') satisfies $x eq local-name(.)]"
                  mode="rm_priv"/>
    <xsl:template xmlns:pf="http://docs.rackspace.com/event/servers/hostserver"
-                 match="pf:product[@version='2']/@*[some $x in ('coreID', 'huddleID', 'backstageURL') satisfies $x eq local-name(.)]"
+                 match="pf:product[@version='2']/@*[some $x in ('backstageURL', 'coreID', 'huddleID') satisfies $x eq local-name(.)]"
                  mode="rm_priv"/>
 
     <!--For product: Widget -->
     <xsl:template xmlns:pf="http://docs.rackspace.com/usage/widget"
-                 match="pf:product[@version='3']/@*[some $x in ('privateAttribute1', 'myAttribute', 'privateAttribute3') satisfies $x eq local-name(.)]"
+                 match="pf:product[@version='3']/@*[some $x in ('myAttribute', 'privateAttribute1', 'privateAttribute3') satisfies $x eq local-name(.)]"
                  mode="rm_priv"/>
    <xsl:template xmlns:pf="http://docs.rackspace.com/usage/widget"
                  match="pf:product[@version='3']/pf:metaData/@*[some $x in ('value') satisfies $x eq local-name(.)]"


### PR DESCRIPTION
Taking out the timat jar artifact.  Its no longer used by SUS to verify the
xslt.  We'll use git submodules.