### PR TITLE
CF-1260 - Tiamat does not honor -r setting

### DIFF
--- a/tiamat/src/main/scala/com/rackspace/feeds/archives/Preferences.scala
+++ b/tiamat/src/main/scala/com/rackspace/feeds/archives/Preferences.scala
@@ -37,9 +37,10 @@ object Preferences {
   /**
    * Create map entry of tenant id -> TenantPreferences
    *
-   * @param regions
-   * @param row
-   * @return
+   * @param regions - list of regions to be archived
+   * @param row - tenant's preferences data from hive
+   *
+   * @return - tenant id -> TenantPreferences
    */
   def tenantContainers(regions : Seq[String], row: Row): List[(String, TenantPrefs)] = {
 
@@ -57,10 +58,12 @@ object Preferences {
       case false => List()
       case true => {
 
+        // if a default container exists, get the default and create the map of region => container
         val containers = if ( isNotBlank( prefs.get( "default_archive_container_url" ) ) ) {
 
           val default_con = prefs.get("default_archive_container_url").getTextValue
 
+          // for only regions which are to be archived
           regions.map(dc =>
 
             if (urls == null)
@@ -74,11 +77,16 @@ object Preferences {
             }
           ).toMap[String, String]
         }
+        // if no default container, and no map of explicit region containers, return empty map.
         else if (urls == null)
           Map[String, String]()
+        // if no default container, create region => container map based on explicit region containers.
         else {
 
-          urls.getFields.flatMap( entry =>
+          urls.getFields
+            // only create entry for regions which will be archived
+            .filter( entry => regions.contains( entry.getKey ) )
+            .flatMap( entry =>
 
             isNotBlank( entry.getValue ) match {
 

--- a/tiamat/src/test/scala/com.rackspace.feeds.archives/PreferencesTest.scala
+++ b/tiamat/src/test/scala/com.rackspace.feeds.archives/PreferencesTest.scala
@@ -93,6 +93,35 @@ class PreferencesTest extends FunSuite with MockitoSugar {
       """
         { "enabled": true,
           "data_format" : [ "JSON", "XML" ],
+          "archive_container_urls": {
+            "reg1" : "http://reg1",
+            "reg2" : "http://reg2",
+            "reg3" : "http://reg3"
+          }
+        }
+      """
+
+    val mockRow = createRow( "tid1", payload , "aid1", true)
+    val list = tenantContainers( Seq( "reg1", "reg2", "reg3" ), mockRow )
+
+    assert( list.size == 1 )
+
+    val prefs = list( 0 )._2
+
+    assert( prefs.formats == List( "JSON", "XML") )
+    assert( prefs.alternateId == "aid1" )
+    assert( prefs.containers.size == 3 )
+    assert( prefs.containers( "reg1") == "http://reg1" )
+    assert( prefs.containers( "reg2") == "http://reg2" )
+    assert( prefs.containers( "reg3") == "http://reg3" )
+  }
+
+  test( "Default, no containers specified" ) {
+
+    val payload =
+      """
+        { "enabled": true,
+          "data_format" : [ "JSON", "XML" ],
           "default_archive_container_url" : "http://defaultContainer",
           "archive_container_urls": {
           }
@@ -133,5 +162,63 @@ class PreferencesTest extends FunSuite with MockitoSugar {
     assert( prefs.formats == List( "JSON", "XML") )
     assert( prefs.alternateId == "aid1" )
     assert( prefs.containers.size == 0 )
+  }
+
+  test( "No default, only archive 'reg1'" ) {
+
+    val payload =
+      """
+        { "enabled": true,
+          "data_format" : [ "JSON", "XML" ],
+          "archive_container_urls": {
+             "reg1" : "http://reg1",
+             "reg2" : "http://reg2",
+             "reg3" : "http://reg3"
+          }
+        }
+      """
+
+    val mockRow = createRow( "tid1", payload , "aid1", true)
+    val list = tenantContainers( Seq( "reg1" ), mockRow )
+
+    assert( list.size == 1 )
+
+    val prefs = list( 0 )._2
+
+    assert( prefs.formats == List( "JSON", "XML") )
+    assert( prefs.alternateId == "aid1" )
+    assert( prefs.containers.size == 1 )
+    assert( prefs.containers( "reg1") == "http://reg1" )
+    assert( !prefs.containers.contains( "reg2") )
+    assert( !prefs.containers.contains( "reg3") )
+  }
+
+  test( "Default & containers, only archive 'reg1' & 'reg2' " ) {
+
+    val payload =
+      """
+        { "enabled": true,
+          "data_format" : [ "JSON", "XML" ],
+          "default_archive_container_url" : "http://defaultContainer",
+          "archive_container_urls": {
+             "reg2" : "http://reg2",
+             "reg3" : "http://reg3"
+          }
+        }
+      """
+
+    val mockRow = createRow( "tid1", payload , "aid1", true)
+    val list = tenantContainers( Seq( "reg1", "reg2" ), mockRow )
+
+    assert( list.size == 1 )
+
+    val prefs = list( 0 )._2
+
+    assert( prefs.formats == List( "JSON", "XML") )
+    assert( prefs.alternateId == "aid1" )
+    assert( prefs.containers.size == 2 )
+    assert( prefs.containers( "reg1") == "http://defaultContainer" )
+    assert( prefs.containers( "reg2") == "http://reg2" )
+    assert( !prefs.containers.contains( "reg3") )
   }
 }


### PR DESCRIPTION
Fix a bug that prevented the following
- when no default container is configured for a tenant
   and a subset of regions are archived (using tiamat's -r option)
- Only the request region is archived for the tenant