### PR TITLE
CF-1219 - Tiamat logging.

### DIFF
--- a/tiamat/build.gradle
+++ b/tiamat/build.gradle
@@ -100,6 +100,7 @@ ospackage {
         into config_path
         include 'tiamat.conf'
         include 'log4j.properties'
+        include 'log4j-local.properties'
         // set permissions
         user app_user
         permissionGroup app_group

--- a/tiamat/src/main/resources/log4j-local.properties
+++ b/tiamat/src/main/resources/log4j-local.properties
@@ -2,7 +2,7 @@ log4j.rootCategory=INFO, file
 
 log4j.appender.file=org.apache.log4j.DailyRollingFileAppender
 log4j.appender.file.layout=org.apache.log4j.PatternLayout
-log4j.appender.file.file=${spark.yarn.app.container.log.dir}/spark.log
+log4j.appender.file.file=/var/log/cloudfeeds-nabu/tiamat/tiamat.log
 log4j.appender.file.DatePattern='.'yyyy-MM-dd-HH-mm
 log4j.appender.file.layout.ConversionPattern=%d{yy/MM/dd HH:mm:ss} %p %c{1}: %m%n
 

--- a/tiamat/src/main/resources/log4j.properties
+++ b/tiamat/src/main/resources/log4j.properties
@@ -2,7 +2,7 @@ log4j.rootCategory=INFO, file
 
 log4j.appender.file=org.apache.log4j.DailyRollingFileAppender
 log4j.appender.file.layout=org.apache.log4j.PatternLayout
-log4j.appender.file.file=${spark.yarn.app.container.log.dir}/spark.log
+log4j.appender.file.file=${spark.yarn.app.container.log.dir}/tiamat-spark.log
 log4j.appender.file.DatePattern='.'yyyy-MM-dd-HH-mm
 log4j.appender.file.layout.ConversionPattern=%d{yy/MM/dd HH:mm:ss} %p %c{1}: %m%n
 

--- a/tiamat/src/main/resources/tiamat.sh
+++ b/tiamat/src/main/resources/tiamat.sh
@@ -4,5 +4,6 @@ SPARK_HOME=/usr/hdp/2.2.0.0-2041/spark
 TIAMAT_HOME=/opt/cloudfeeds-nabu/tiamat
 
 ${SPARK_HOME}/bin/spark-submit --class com.rackspace.feeds.archives.Tiamat \
-   --driver-java-options "-Dlog4j.configuration=file:///etc/cloudfeeds-nabu/tiamat/log4j.properties" \
+   --files /etc/cloudfeeds-nabu/tiamat/log4j.properties \
+   --driver-java-options "-Dlog4j.configuration=file:///etc/cloudfeeds-nabu/tiamat/log4j-local.properties" \
    --master yarn-client ${TIAMAT_HOME}/lib/cloudfeeds-nabu-tiamat.jar "$@"


### PR DESCRIPTION
Updated logging to enable the following:
- The local driver app writes logs to /var/cloudfeeds-nabu/tiamat/tiamat.log*
- The executors log to the application log on HDFS

Enabled this by adding a local log4j file, and a general log4j file
which writes to the HDFS appplication log