### PR TITLE
CF-1349: update nonStringAttrs.xsl due to new neutron schema

### DIFF
--- a/tiamat/src/main/resources/nonStringAttrs.xsl
+++ b/tiamat/src/main/resources/nonStringAttrs.xsl
@@ -149,6 +149,9 @@
       <schema key="http://docs.rackspace.com/usage/maas" version="2">
          <attributes>product/@monitoringZones</attributes>
       </schema>
+      <schema key="http://docs.rackspace.com/usage/neutron/ip" version="1">
+         <attributes>product/@public</attributes>
+      </schema>
       <schema key="http://docs.rackspace.com/usage/neutron/ipbandwidth" version="1">
          <attributes>product/@bandwidthOut</attributes>
       </schema>


### PR DESCRIPTION
This PR updates the `nonStringAttrs.xsl` file to incorporate a new Neutron schema.
See: https://jira.rax.io/browse/CF-1349
See: https://github.com/rackerlabs/standard-usage-schemas/pull/580