### PR TITLE
adding new attributes from standard usage schemas

### DIFF
--- a/tiamat/src/main/resources/nonStringAttrs.xsl
+++ b/tiamat/src/main/resources/nonStringAttrs.xsl
@@ -143,6 +143,9 @@
       <schema key="http://docs.rackspace.com/usage/lbaas" version="1">
          <attributes>product/@avgConcurrentConnections,product/@avgConcurrentConnectionsSsl,product/@avgConcurrentConnectionsSum,product/@bandWidthIn,product/@bandWidthInSsl,product/@bandWidthOut,product/@bandWidthOutSsl,product/@hasSSLConnection,product/@numPolls,product/@numVips,product/@publicBandWidthInSum,product/@publicBandWidthOutSum</attributes>
       </schema>
+      <schema key="http://docs.rackspace.com/usage/lbaas/connections" version="2">
+         <attributes>product/@connections,product/@isSSL</attributes>
+      </schema>
       <schema key="http://docs.rackspace.com/usage/maas" version="1">
          <attributes>product/@monitoringZones</attributes>
       </schema>


### PR DESCRIPTION
Somehow the lbaas attribute never got added from a previous PR (https://github.com/rackerlabs/standard-usage-schemas/pull/579).  Not sure how that slipped through.  github reports that the PR checks passed.