### PR TITLE
updating to spark 1.6

### DIFF
--- a/tiamat/build.gradle
+++ b/tiamat/build.gradle
@@ -60,8 +60,8 @@ def app_group = 'cloudfeeds'
 dependencies {
 
     compile 'org.scala-lang:scala-library:2.10.4'
-    compile 'org.apache.spark:spark-core_2.10:1.3.1'
-    compile 'org.apache.spark:spark-hive_2.10:1.3.1'
+    compile 'org.apache.spark:spark-core_2.10:1.6.0'
+    compile 'org.apache.spark:spark-hive_2.10:1.6.0'
     compile 'org.json4s:json4s-jackson_2.10:3.2.11'
     compile 'org.apache.httpcomponents:httpclient:4.3'
     compile 'joda-time:joda-time:2.7'


### PR DESCRIPTION
Updating to spark 1.6 to match the new version of Hadoop on the caspian cluster.