### PR TITLE
Synced nonStringAttrs.xsl for ticketing feed update

### DIFF
--- a/tiamat/src/main/resources/nonStringAttrs.xsl
+++ b/tiamat/src/main/resources/nonStringAttrs.xsl
@@ -75,9 +75,6 @@
       <schema key="http://docs.rackspace.com/event/support/account/teams" version="1">
          <attributes>team/@previousTeamNumber,team/@suppressNotifications,team/@teamNumber</attributes>
       </schema>
-      <schema key="http://docs.rackspace.com/event/ticketing/queue/view" version="1">
-         <attributes>product/@number</attributes>
-      </schema>
       <schema key="http://docs.rackspace.com/event/ticketing/ticket" version="1">
          <attributes>queue/@id</attributes>
       </schema>


### PR DESCRIPTION
Synced nonStringAttrs.xsl to update ticketing/queue/view to reflect that product/@number is now a string (used to be an int).