### PR TITLE
Synced nonStringAttrs.xsl for Ticketing feed update

### DIFF
--- a/tiamat/src/main/resources/nonStringAttrs.xsl
+++ b/tiamat/src/main/resources/nonStringAttrs.xsl
@@ -87,9 +87,6 @@
       <schema key="http://docs.rackspace.com/event/support/account/teams" version="1">
          <attributes>team/@previousTeamNumber,team/@suppressNotifications,team/@teamNumber</attributes>
       </schema>
-      <schema key="http://docs.rackspace.com/event/ticketing/ticket" version="1">
-         <attributes>queue/@id</attributes>
-      </schema>
       <schema key="http://docs.rackspace.com/event/tricore/ticket" version="1">
          <attributes>nextAction/@id,notes/@isPublic</attributes>
       </schema>


### PR DESCRIPTION
Syncing the `nonStringAttrs.xsl` change from the Standard Usage Schema repo to this repo.