### PR TITLE
Synced nonStringAttrs.xsl for Support feed update

### DIFF
--- a/tiamat/src/main/resources/nonStringAttrs.xsl
+++ b/tiamat/src/main/resources/nonStringAttrs.xsl
@@ -87,6 +87,12 @@
       <schema key="http://docs.rackspace.com/event/support/account/teams" version="1">
          <attributes>team/@previousTeamNumber,team/@suppressNotifications,team/@teamNumber</attributes>
       </schema>
+      <schema key="http://docs.rackspace.com/event/support/team" version="1">
+         <attributes>product/@teamNumber</attributes>
+      </schema>
+      <schema key="http://docs.rackspace.com/event/support/team/roles" version="1">
+         <attributes>role/@roleId,role/@suppressNotifications,product/@teamNumber</attributes>
+      </schema>
       <schema key="http://docs.rackspace.com/event/tricore/ticket" version="1">
          <attributes>nextAction/@id,notes/@isPublic</attributes>
       </schema>


### PR DESCRIPTION
Syncing the `nonStringAttrs.xsl` change from the Standard Usage Schema repo to this repo.

https://github.com/rackerlabs/standard-usage-schemas/pull/642
