### PR TITLE
Synced nonStringAttrs.xsl for new User Integration feed

### DIFF
--- a/tiamat/src/main/resources/nonStringAttrs.xsl
+++ b/tiamat/src/main/resources/nonStringAttrs.xsl
@@ -36,6 +36,9 @@
       <schema key="http://docs.rackspace.com/event/dpservicenow/task" version="1">
          <attributes>product/@clientVisible,product/@publicCorrespondenceAdded,product/@workNoteAdded</attributes>
       </schema>
+      <schema key="http://docs.rackspace.com/event/dpservicenow/user" version="1">
+         <attributes>product/@active</attributes>
+      </schema>
       <schema key="http://docs.rackspace.com/event/identity/user" version="1">
          <attributes>product/@migrated,product/@multiFactorEnabled</attributes>
       </schema>


### PR DESCRIPTION
Syncing the `nonStringAttrs.xsl` change from the Standard Usage Schema repo to this repo.

https://github.com/rackerlabs/standard-usage-schemas/pull/648