### PR TITLE
Synced nonStringAttrs.xsl for Support Team updates

### DIFF
--- a/tiamat/src/main/resources/nonStringAttrs.xsl
+++ b/tiamat/src/main/resources/nonStringAttrs.xsl
@@ -96,7 +96,13 @@
       <schema key="http://docs.rackspace.com/event/support/team" version="1">
          <attributes>product/@teamNumber</attributes>
       </schema>
+      <schema key="http://docs.rackspace.com/event/support/team" version="2">
+         <attributes>product/@teamNumber</attributes>
+      </schema>
       <schema key="http://docs.rackspace.com/event/support/team/roles" version="1">
+         <attributes>role/@roleId,role/@suppressNotifications,product/@teamNumber</attributes>
+      </schema>
+      <schema key="http://docs.rackspace.com/event/support/team/roles" version="2">
          <attributes>role/@roleId,role/@suppressNotifications,product/@teamNumber</attributes>
       </schema>
       <schema key="http://docs.rackspace.com/event/tricore/ticket" version="1">


### PR DESCRIPTION
Syncing the `nonStringAttrs.xsl` change from the Standard Usage Schema repo to this repo.

https://github.com/rackerlabs/standard-usage-schemas/pull/656